### PR TITLE
Allow users to specify which entity to notify

### DIFF
--- a/opsdroid_homeassistant/skill/__init__.py
+++ b/opsdroid_homeassistant/skill/__init__.py
@@ -122,7 +122,9 @@ class HassSkill(Skill):
         else:
             _LOGGER.error("Unable to set value for unsupported entity %s", entity_id)
 
-    async def notify(self, message: str, title="Home Assistant": str, target="notify": str, **kwargs):
+    async def notify(
+        self, message: str, title="Home Assistant", target="notify", **kwargs
+    ):
         """Send a notification to Home Assistant.
 
         Sends a ``notify.notify`` service call with the specified title and message.
@@ -270,4 +272,6 @@ class HassSkill(Skill):
             Jacob is at home!
 
         """
-        return await self.hass.query_api("template", method="POST", decode_json=False, template=template)
+        return await self.hass.query_api(
+            "template", method="POST", decode_json=False, template=template
+        )

--- a/opsdroid_homeassistant/skill/__init__.py
+++ b/opsdroid_homeassistant/skill/__init__.py
@@ -122,13 +122,18 @@ class HassSkill(Skill):
         else:
             _LOGGER.error("Unable to set value for unsupported entity %s", entity_id)
 
-    async def notify(self, title: str, message: str, **kwargs):
+    async def notify(self, message: str, title="Home Assistant": str, target="notify": str, **kwargs):
         """Send a notification to Home Assistant.
 
         Sends a ``notify.notify`` service call with the specified title and message.
+
+        Args:
+            message: A message to notify with.
+            title (optional): A title to set in the notification.
+            target (optional): The notification target. Defaults to ``notify`` which will notify all.
         """
         await self.call_service(
-            "notify", "notify", message=message, title=title, **kwargs
+            "notify", target, message=message, title=title, **kwargs
         )
 
     async def sun_up(self):


### PR DESCRIPTION
Instead of only sending a notification to `notify.notify` user's can specify the target entity with the `target` kwarg.