### PR TITLE
Catch websocket handshake exception

### DIFF
--- a/opsdroid_homeassistant/connector/__init__.py
+++ b/opsdroid_homeassistant/connector/__init__.py
@@ -43,13 +43,13 @@ class HassConnector(Connector):
         self.listening = None
         self.discovery_info = None
         self.token = self.config.get("token")
-        self.api_url = urllib.parse.urljoin(self.config.get("url"), "/api/")
+        self.api_url = urllib.parse.urljoin(self.config.get("url"), "api/")
 
         # The websocket URL can differ depending on how Home Assistant was installed.
         # So we will iterate over the various urls when attempting to connect.
         self.websocket_urls = [
             urllib.parse.urljoin(self.api_url, "websocket"),  # Plain Home Assistant
-            urllib.parse.urljoin(self.config.get("url"), "/websocket"),  # Hassio proxy
+            urllib.parse.urljoin(self.config.get("url"), "websocket"),  # Hassio proxy
         ]
         self.id = 1
 

--- a/opsdroid_homeassistant/connector/__init__.py
+++ b/opsdroid_homeassistant/connector/__init__.py
@@ -70,6 +70,7 @@ class HassConnector(Connector):
                         async with session.ws_connect(websocket_url) as ws:
                             self.connection = ws
                             async for msg in self.connection:
+                                _LOGGER.debug(msg.data)
                                 if msg.type == aiohttp.WSMsgType.TEXT:
                                     await self._handle_message(json.loads(msg.data))
                                 elif msg.type == aiohttp.WSMsgType.ERROR:

--- a/opsdroid_homeassistant/connector/__init__.py
+++ b/opsdroid_homeassistant/connector/__init__.py
@@ -74,7 +74,10 @@ class HassConnector(Connector):
                                 elif msg.type == aiohttp.WSMsgType.ERROR:
                                     break
                         _LOGGER.info("Home Assistant closed the websocket, retrying...")
-                    except aiohttp.client_exceptions.ClientConnectorError:
+                    except (
+                        aiohttp.client_exceptions.ClientConnectorError,
+                        aiohttp.client_exceptions.WSServerHandshakeError,
+                    ):
                         _LOGGER.info("Unable to connect to Home Assistant, retrying...")
                     await asyncio.sleep(1)
 

--- a/opsdroid_homeassistant/connector/__init__.py
+++ b/opsdroid_homeassistant/connector/__init__.py
@@ -58,6 +58,7 @@ class HassConnector(Connector):
         return self.id
 
     async def connect(self):
+        _LOGGER.debug("Connecting with token " + self.token)
         self.discovery_info = await self.query_api("discovery_info")
         self.listening = True
 
@@ -77,6 +78,7 @@ class HassConnector(Connector):
                     except (
                         aiohttp.client_exceptions.ClientConnectorError,
                         aiohttp.client_exceptions.WSServerHandshakeError,
+                        aiohttp.client_exceptions.ServerDisconnectedError,
                     ):
                         _LOGGER.info("Unable to connect to Home Assistant, retrying...")
                     await asyncio.sleep(1)

--- a/opsdroid_homeassistant/connector/__init__.py
+++ b/opsdroid_homeassistant/connector/__init__.py
@@ -58,7 +58,6 @@ class HassConnector(Connector):
         return self.id
 
     async def connect(self):
-        _LOGGER.debug("Connecting with token " + self.token)
         self.discovery_info = await self.query_api("discovery_info")
         self.listening = True
 
@@ -70,7 +69,6 @@ class HassConnector(Connector):
                         async with session.ws_connect(websocket_url) as ws:
                             self.connection = ws
                             async for msg in self.connection:
-                                _LOGGER.debug(msg.data)
                                 if msg.type == aiohttp.WSMsgType.TEXT:
                                     await self._handle_message(json.loads(msg.data))
                                 elif msg.type == aiohttp.WSMsgType.ERROR:


### PR DESCRIPTION
It seems that when connecting to the regular websocket url from within a hassio addon it raises a handshake exception.

In #8 supprt was added for the alternate url, this must be why that alternate url exists.