### PR TITLE
Add opsdroid fixture and some small tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+source = opsdroid_homeassistant
+
+[report]
+show_missing = True
+omit =
+    opsdroid_homeassistant/_version.py
+    opsdroid_homeassistant/tests/*

--- a/opsdroid_homeassistant/tests/conftest.py
+++ b/opsdroid_homeassistant/tests/conftest.py
@@ -57,15 +57,15 @@ def connector(connector_config):
 
 
 @pytest.fixture
-def test_skill_path():
-    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_skill")
+def mock_skill_path():
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "mock_skill")
 
 
 @pytest.fixture
-async def opsdroid(connector_config, test_skill_path):
+async def opsdroid(connector_config, mock_skill_path):
     config = {
         "connectors": {"homeassistant": connector_config},
-        "skills": {"test": {"path": test_skill_path}},
+        "skills": {"test": {"path": mock_skill_path}},
     }
     configure_lang({})
     with OpsDroid(config) as opsdroid:
@@ -82,5 +82,5 @@ async def connector(opsdroid):
 
 
 @pytest.fixture
-async def test_skill(opsdroid):
-    return opsdroid.test_skill
+async def mock_skill(opsdroid):
+    return opsdroid.mock_skill

--- a/opsdroid_homeassistant/tests/mock_skill/__init__.py
+++ b/opsdroid_homeassistant/tests/mock_skill/__init__.py
@@ -5,7 +5,7 @@ from opsdroid_homeassistant import HassSkill
 class TestSkill(HassSkill):
     def __init__(self, opsdroid, config, *args, **kwargs):
         super().__init__(opsdroid, config, *args, **kwargs)
-        opsdroid.test_skill = self
+        opsdroid.mock_skill = self
 
     @match_regex(r"Turn on the light")
     async def lights_on(self, event):

--- a/opsdroid_homeassistant/tests/test_connector.py
+++ b/opsdroid_homeassistant/tests/test_connector.py
@@ -1,26 +1,32 @@
 import pytest
-import requests
 
-from opsdroid_homeassistant import HassConnector
-
-
-@pytest.fixture
-def config(homeassistant, access_token):
-    return {"token": access_token, "url": homeassistant}
+from opsdroid.events import Message
 
 
-@pytest.fixture
-def connector(config):
-    return HassConnector(config, opsdroid=None)
-
-
-def test_attributes(connector):
+@pytest.mark.asyncio
+async def test_attributes(connector):
     assert connector.name == "homeassistant"
     assert connector.default_target is None
 
 
 @pytest.mark.asyncio
 async def test_connect(connector):
-    await connector.connect()
     assert connector.listening
     assert "version" in connector.discovery_info
+
+
+@pytest.mark.asyncio
+async def test_turn_on_off_toggle(opsdroid, test_skill):
+    assert await test_skill.get_state("light.bed_light") == "off"
+
+    await opsdroid.parse(Message("Turn on the light"))
+    assert await test_skill.get_state("light.bed_light") == "on"
+
+    await opsdroid.parse(Message("Turn off the light"))
+    assert await test_skill.get_state("light.bed_light") == "off"
+
+    await opsdroid.parse(Message("Toggle the light"))
+    assert await test_skill.get_state("light.bed_light") == "on"
+
+    await opsdroid.parse(Message("Toggle the light"))
+    assert await test_skill.get_state("light.bed_light") == "off"

--- a/opsdroid_homeassistant/tests/test_connector.py
+++ b/opsdroid_homeassistant/tests/test_connector.py
@@ -1,5 +1,7 @@
 import pytest
 
+from asyncio import sleep
+
 from opsdroid.events import Message
 
 
@@ -20,13 +22,17 @@ async def test_turn_on_off_toggle(opsdroid, test_skill):
     assert await test_skill.get_state("light.bed_light") == "off"
 
     await opsdroid.parse(Message("Turn on the light"))
+    await sleep(0.1)
     assert await test_skill.get_state("light.bed_light") == "on"
 
     await opsdroid.parse(Message("Turn off the light"))
+    await sleep(0.1)
     assert await test_skill.get_state("light.bed_light") == "off"
 
     await opsdroid.parse(Message("Toggle the light"))
+    await sleep(0.1)
     assert await test_skill.get_state("light.bed_light") == "on"
 
     await opsdroid.parse(Message("Toggle the light"))
+    await sleep(0.1)
     assert await test_skill.get_state("light.bed_light") == "off"

--- a/opsdroid_homeassistant/tests/test_connector.py
+++ b/opsdroid_homeassistant/tests/test_connector.py
@@ -15,24 +15,3 @@ async def test_attributes(connector):
 async def test_connect(connector):
     assert connector.listening
     assert "version" in connector.discovery_info
-
-
-@pytest.mark.asyncio
-async def test_turn_on_off_toggle(opsdroid, test_skill):
-    assert await test_skill.get_state("light.bed_light") == "off"
-
-    await opsdroid.parse(Message("Turn on the light"))
-    await sleep(0.1)
-    assert await test_skill.get_state("light.bed_light") == "on"
-
-    await opsdroid.parse(Message("Turn off the light"))
-    await sleep(0.1)
-    assert await test_skill.get_state("light.bed_light") == "off"
-
-    await opsdroid.parse(Message("Toggle the light"))
-    await sleep(0.1)
-    assert await test_skill.get_state("light.bed_light") == "on"
-
-    await opsdroid.parse(Message("Toggle the light"))
-    await sleep(0.1)
-    assert await test_skill.get_state("light.bed_light") == "off"

--- a/opsdroid_homeassistant/tests/test_skill.py
+++ b/opsdroid_homeassistant/tests/test_skill.py
@@ -1,0 +1,44 @@
+import pytest
+
+from asyncio import sleep
+
+from opsdroid.events import Message
+
+
+@pytest.mark.asyncio
+async def test_turn_on_off_toggle(opsdroid, mock_skill):
+    assert await mock_skill.get_state("light.bed_light") == "off"
+
+    await opsdroid.parse(Message("Turn on the light"))
+    await sleep(0.1)
+    assert await mock_skill.get_state("light.bed_light") == "on"
+
+    await opsdroid.parse(Message("Turn off the light"))
+    await sleep(0.1)
+    assert await mock_skill.get_state("light.bed_light") == "off"
+
+    await opsdroid.parse(Message("Toggle the light"))
+    await sleep(0.1)
+    assert await mock_skill.get_state("light.bed_light") == "on"
+
+    await opsdroid.parse(Message("Toggle the light"))
+    await sleep(0.1)
+    assert await mock_skill.get_state("light.bed_light") == "off"
+
+
+@pytest.mark.asyncio
+async def test_sun_states(mock_skill):
+    from datetime import datetime
+
+    assert isinstance(await mock_skill.sun_up(), bool)
+    assert isinstance(await mock_skill.sun_down(), bool)
+    assert isinstance(await mock_skill.sunset(), datetime)
+    assert isinstance(await mock_skill.sunrise(), datetime)
+
+    assert await mock_skill.sun_up() or await mock_skill.sun_down()
+    assert not await mock_skill.sun_up() and await mock_skill.sun_down()
+
+    if await mock_skill.sun_up():
+        assert await mock_skill.sunset() < await mock_skill.sunrise()
+    else:
+        assert await mock_skill.sunset() > await mock_skill.sunrise()

--- a/opsdroid_homeassistant/tests/test_skill.py
+++ b/opsdroid_homeassistant/tests/test_skill.py
@@ -36,7 +36,7 @@ async def test_sun_states(mock_skill):
     assert isinstance(await mock_skill.sunrise(), datetime)
 
     assert await mock_skill.sun_up() or await mock_skill.sun_down()
-    assert not await mock_skill.sun_up() and await mock_skill.sun_down()
+    assert not (await mock_skill.sun_up() and await mock_skill.sun_down())
 
     if await mock_skill.sun_up():
         assert await mock_skill.sunset() < await mock_skill.sunrise()

--- a/opsdroid_homeassistant/tests/test_skill/__init__.py
+++ b/opsdroid_homeassistant/tests/test_skill/__init__.py
@@ -1,0 +1,20 @@
+from opsdroid.matchers import match_regex
+from opsdroid_homeassistant import HassSkill
+
+
+class TestSkill(HassSkill):
+    def __init__(self, opsdroid, config, *args, **kwargs):
+        super().__init__(opsdroid, config, *args, **kwargs)
+        opsdroid.test_skill = self
+
+    @match_regex(r"Turn on the light")
+    async def lights_on(self, event):
+        await self.turn_on("light.bed_light")
+
+    @match_regex(r"Turn off the light")
+    async def lights_off(self, event):
+        await self.turn_off("light.bed_light")
+
+    @match_regex(r"Toggle the light")
+    async def lights_toggle(self, event):
+        await self.toggle("light.bed_light")


### PR DESCRIPTION
This PR adds a new fixture which starts opsdroid connected to the existing home assistant service fixture and loads a test skill.

I've also added a test which uses the test skill to toggle a demo light a few times.

I've also just done some general tidying of fixtures and added a coveragerc file.