### PR TITLE
Fix for opsdroid 0.20+ compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ after_success: codecov
 jobs:
   fast_finish: true
   include:
-    - python: "3.6"
     - python: "3.7"
     - python: "3.8"
     - stage: deploy

--- a/opsdroid_homeassistant/skill/__init__.py
+++ b/opsdroid_homeassistant/skill/__init__.py
@@ -41,11 +41,18 @@ class HassSkill(Skill):
 
     def __init__(self, opsdroid, config, *args, **kwargs):
         super().__init__(opsdroid, config, *args, **kwargs)
-        [self.hass] = [
-            connector
-            for connector in self.opsdroid.connectors
-            if connector.name == "homeassistant"
-        ]
+        self._hass = None
+
+    @property
+    def hass(self):
+        if self._hass is None:
+            # create lazily (opsdroid.connectors not yet known when __init__ called)
+            [self._hass] = [
+                connector
+                for connector in self.opsdroid.connectors
+                if connector.name == "homeassistant"
+            ]
+        return self._hass
 
     async def call_service(self, domain: str, service: str, *args, **kwargs):
         """Send a service call to Home Assistant.

--- a/opsdroid_homeassistant/tests/conftest.py
+++ b/opsdroid_homeassistant/tests/conftest.py
@@ -55,7 +55,6 @@ def connector_config(homeassistant, access_token):
 def connector(connector_config):
     return HassConnector(config, opsdroid=None)
 
-
 @pytest.fixture
 def mock_skill_path():
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), "mock_skill")
@@ -70,8 +69,10 @@ async def opsdroid(connector_config, mock_skill_path):
     configure_lang({})
     with OpsDroid(config) as opsdroid:
         await opsdroid.load()
+        await opsdroid.start_connectors()
         await sleep(0.1)  # Give the startup tasks some room to breathe
         yield opsdroid
+        await opsdroid.stop()
         await opsdroid.unload()
 
 

--- a/opsdroid_homeassistant/tests/conftest.py
+++ b/opsdroid_homeassistant/tests/conftest.py
@@ -55,6 +55,7 @@ def connector_config(homeassistant, access_token):
 def connector(connector_config):
     return HassConnector(config, opsdroid=None)
 
+
 @pytest.fixture
 def mock_skill_path():
     return os.path.join(os.path.dirname(os.path.abspath(__file__)), "mock_skill")


### PR DESCRIPTION
Fixes #20.

Before Opsdroid 0.20 the connectors were created before the skills, but now it's the other way around. That means `opsdroid.connectors` is now still empty when the skill's `__init__()` is called, which causes an error when trying to set the `hass` variable.

This PR solves that by introducing a lazily evaluated property for `hass`. By the time the property is first needed, the connectors will have been loaded, and the Home Assistant connector can be looked up to populate the `hass` property.

Tested locally by reproducing the problem (easy ;-)) and validating that after the fix the problem is no longer present. Steps to reproduce and validate: see #20.